### PR TITLE
Roll back transaction on failed ExecContext

### DIFF
--- a/adapter/sqlite/database.go
+++ b/adapter/sqlite/database.go
@@ -82,6 +82,7 @@ func (*database) StatementExec(sess sqladapter.Session, ctx context.Context, que
 	}
 
 	if res, err = compat.ExecContext(sqlTx, ctx, query, args); err != nil {
+		_ = sqlTx.Rollback()
 		return nil, err
 	}
 

--- a/internal/testsuite/sql_suite.go
+++ b/internal/testsuite/sql_suite.go
@@ -142,9 +142,6 @@ func (s *SQLTestSuite) TestPreparedStatementsCache() {
 	switch s.Adapter() {
 	case "ql":
 		limit = 1000
-	case "sqlite":
-		// TODO: We'll probably be able to workaround this with a mutex on inserts.
-		s.T().Skip(`Skipped due to a "database is locked" problem with concurrent transactions. See https://github.com/mattn/go-sqlite3/issues/274`)
 	}
 
 	for i := 0; i < limit; i++ {


### PR DESCRIPTION
Call sqlTx.Rollback if an error is returned by compat.ExecContext in the SQLite adapter